### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/aiw-devops/ac42984b-a35a-489c-a507-9a0df871cc3b/49c6cead-09ce-4c76-b2ab-0806760647c1/_apis/work/boardbadge/2d4dfd72-155c-4420-a77b-84de711ac6fc)](https://dev.azure.com/aiw-devops/ac42984b-a35a-489c-a507-9a0df871cc3b/_boards/board/t/49c6cead-09ce-4c76-b2ab-0806760647c1/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1203](https://dev.azure.com/aiw-devops/ac42984b-a35a-489c-a507-9a0df871cc3b/_workitems/edit/1203). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.